### PR TITLE
Fixes for BSD sed/awk and for ansi2html

### DIFF
--- a/gemini.filter.dpi
+++ b/gemini.filter.dpi
@@ -102,7 +102,7 @@ render_gemini() {
 			if (!text) {
 				text = href
 			}
-			if (match(href, /^gemini:\/\/[^/]+$/)) {
+			if (match(href, /^gemini:\/\/[^\/]+$/)) {
 				href = href "/"
 			}
 			sub(/^\t+/, "", prefix)

--- a/gemini.filter.dpi
+++ b/gemini.filter.dpi
@@ -29,7 +29,7 @@ render_gemini() {
 	cat ~/.dillo/dpi/gemini/style.css || true
 	printf "</style></head>\n"
 	if command -v ansi2html >/dev/null
-	then ansi2html
+	then ansi2html -iu
 	else cat
 	fi | awk '
 		function escape_html(str) {

--- a/gemini.filter.dpi
+++ b/gemini.filter.dpi
@@ -290,7 +290,7 @@ serve_gemini_response() {
 	url=$1
 	read -r status meta
 	send_status_msg "Status: $status"
-	meta=$(echo "$meta" | sed 's/\s*$//')
+	meta=$(echo "$meta" | sed 's/[[:blank:]]*$//')
 	mkdir -p "$blobs_dir"/tmp ~/.dillo/gemini
 	tmp=$(mktemp "$blobs_dir"/tmp/XXXXXXXXXXXX)
 	tee "$tmp" | case "$status" in


### PR DESCRIPTION
Hello. Today I tried to use this plugin with Dillo for FreeBSD and found that it unable to load any pages from any Gemblogs — Dillo just trying to load the page infinitely.

I found the next problems with `gemini.filter.dpi` shell script.

# GNU-specific \s character class

Looks like the line:

https://github.com/dillo-browser/dillo-plugin-gemini/blob/74184dd792fde977b7c55b159038ad0d8d7f3c7e/gemini.filter.dpi#L293

Should remove trailing spaces from the `$meta` but it was unable to do this with BSD sed. Example:

```
~ λ echo "text/gemini     " | sed 's/\s*$//'
sed: 1: "s/\s*$//
": RE error: trailing backslash (\)
```

According to [man 7 re_format](https://man.freebsd.org/cgi/man.cgi?query=re_format&sektion=7&format=html), there are no such character class in the BRE for BSD sed and the `[:blank:]` should be used. This character class exists both in BSD and GNU sed.

Example:

```
~ λ echo "text/gemini     " | sed 's/[[:blank:]]*$//'
text/gemini~ λ 
```

# BSD awk doesn't allow non-escaped forward slash inside bracket expression

This line in `render_gemini` function produces an error from awk:

https://github.com/dillo-browser/dillo-plugin-gemini/blob/74184dd792fde977b7c55b159038ad0d8d7f3c7e/gemini.filter.dpi#L105

Example:

```
~ λ echo "gemini://test" | awk '{ if (match($0, /^gemini:\/\/[^/]+$/)) { print $0; } }'
/usr/bin/awk: extra ] at source line 1
 context is
    { if (match($0, >>>  /^gemini:\/\/[^/] <<< 
/usr/bin/awk: syntax error at source line 1
/usr/bin/awk: illegal statement at source line 1
    extra ]
```

But escaped slash inside the brackets works as intended:

```
~ λ echo "gemini://test" | awk '{ if (match($0, /^gemini:\/\/[^\/]+$/)) { print "MATCH"; } else { print "no match"; } }'
MATCH
~ λ echo "gemini://test/" | awk '{ if (match($0, /^gemini:\/\/[^\/]+$/)) { print "MATCH"; } else { print "no match"; } }'
no match
```

I've checked this awk program on the Linux with GNU awk and it works the same way as in FreeBSD.

# Lack of options for ansi2html

After mentioned fixes in the `gemini.filter.dpi` I was able to load Gemini pages but the result was far from ideal:

<img width="1230" height="1440" alt="2025-09-02_22:11:13_1440x1230_" src="https://github.com/user-attachments/assets/a9572657-4236-4d72-ac9a-30cf37cc390b" />

As you can see there is a visible HTML code on the page with some `<head></head>` tags and some other HTML tags. And there are no clickable links.

To fix it I add the `-iu` options to the `ansi2html`. Now, with this fix the page looks like normal:

<img width="1120" height="1438" alt="2025-09-02_22:14:41_1438x1120_" src="https://github.com/user-attachments/assets/3ed86230-8598-4c85-a04a-0e5145053ed6" />

-----------------------

All this fixes were applied to the Dillo v3.2.0 on the FreeBSD 14.3-RELEASE-p2. All three described problems were fixed in the three commits in this PR.